### PR TITLE
Add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+tests
+action.yml


### PR DESCRIPTION
## What

Add `.dockerignore` file.

## Why

Lighter images to make the CI faster and improve the network load.
