### PR TITLE
Add `$GITHUB_OUTPUT` to entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ jobs:
           version: 0.6.0
 ```
 
+## Example usage for scan job with Git comment
+
+```yml
+      - name: driftctl Scan Comment
+        uses: actions/github-script@v5.1.0
+        if: github.event_name == 'pull_request'
+        env:
+          DFCTL_SCAN: "#### driftctl Scan 🔎 ${{ steps.driftctl.outputs.driftctl }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### driftctl Scan 🔎\`${{ steps.driftctl.outcome }}\`
+            <details><summary>Show Scan</summary>
+            \n
+            ${process.env.DFCTL_SCAN}
+            \n
+            </details>`;
+              github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+```
+
 ### How to Contribute
 
 Should you wish to make a contribution please open a pull request against this repository with a clear description of the change with tests demonstrating the functionality.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ jobs:
 
 ## Example usage for scan job with Git comment
 
+> **❗Important❗** `continue-on-error` needs to be set as true so the comment job can complete
+
 ```yml
   driftctl:
     runs-on: ubuntu-latest
@@ -48,7 +50,7 @@ jobs:
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
-          DFCTL_SCAN: "#### driftctl Scan 🔎 ${{ steps.driftctl.outputs.driftctl }}"
+          DFCTL_SCAN: "#### driftctl Scan 🔎 ${{ steps.driftctl.outputs.SCAN_OUTPUT }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 
 ```yml
       - name: driftctl Scan Comment
-        uses: actions/github-script@v5.1.0
+        uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
           DFCTL_SCAN: "#### driftctl Scan 🔎 ${{ steps.driftctl.outputs.driftctl }}"
@@ -55,6 +55,10 @@ jobs:
               body: output
             })
 ```
+
+## Optional job syntax
+
+- [continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error): Adding this to your job will ensure that the drfitctl GitHub Action continues when drift is detected or any other error occurs. This is useful when using adding the driftctl Scan output to a GitHub comment.
 
 ### How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ jobs:
 ## Example usage for scan job with Git comment
 
 ```yml
+  driftctl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3    
+      - name: driftctl Scan
+        id: driftctl
+        uses: driftctl-action@v1.2.1
+        continue-on-error: true
+        
       - name: driftctl Scan Comment
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
@@ -55,10 +65,6 @@ jobs:
               body: output
             })
 ```
-
-## Optional job syntax
-
-- [continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error): Adding this to your job will ensure that the drfitctl GitHub Action continues when drift is detected or any other error occurs. This is useful when using adding the driftctl Scan output to a GitHub comment.
 
 ### How to Contribute
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,13 +47,13 @@ qflag=""
 quiet_flag
 
 # Store scan output in variable 
-SCANOUTPUT="$(driftctl scan $qflag $INPUT_ARGS)"
+scan_output="$(driftctl scan $qflag $INPUT_ARGS)"
 
 # Escape scan output to handle multilines
-SCANOUTPUT="${SCANOUTPUT//$'\n'/'%0A'}"
+scan_output="${SCAN_OUTPUT//$'\n'/'%0A'}"
 
 # Set output to be used for other Github Actions jobs
-echo "::set-output name=driftctl::$SCANOUTPUT"
+echo "::set-output name=driftctl::$SCAN_OUTPUT"
 
 # Finally we run the scan command
 driftctl scan $qflag $INPUT_ARGS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ scan_exit=$?
 
 # Check exit code, fail job if scan command exit code 2, then format scan output for GitHub comment
 scan_exit_code(){
-  if [[ "$scan_exit" -eq 1 || "$scan_exit" -eq 2 ]]; then
+  if [ "$scan_exit" -eq 2 ]; then
     echo -e "$scan_output"
     scan_output="${scan_output//$'\n'/'%0A'}"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,19 +61,20 @@ scan_output=$(scan_output)
 # Store exit code from scan command run in scan function
 scan_exit=$?
 
-# Check scan ﬁexit code, fail job if exit code is 1 or 2, then format scan output for GitHub comment
+#Check exit code, echo scan, add delimiter, output to $GITHUB_OUTPUT, and fail job if scan exit code 1 or 2
 scan_exit_code(){
-  if [[ "$scan_exit" -eq 1 || "$scan_exit" -eq 2 ]]; then
+  if [ $1 -eq 1 ]; then
     echo -e "$scan_output"
-    scan_output="${scan_output//$'\n'/'%0A'}"
-    echo "::set-output name=driftctl::$scan_output"
+    echo 'SCAN_OUTPUT<<EOF' >> $GITHUB_OUTPUT
+    echo -e "$scan_output" >> $GITHUB_OUTPUT
+    echo 'EOF' >> $GITHUB_OUTPUT
+    exit $1
+  elif [ $1 -eq 2 ]; then
     exit 1
   else
-    echo -e "$scan_output"
-    scan_output="${scan_output//$'\n'/'%0A'}"
-    echo "::set-output name=driftctl::$scan_output"
+    exit $1
   fi
 }
 
 # Run exit code function 
-scan_exit_code
+scan_exit_code $scan_exit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,5 +46,15 @@ install_driftctl || log_error "Fail to install driftctl"
 qflag=""
 quiet_flag
 
+# Store scan output in variable 
+SCANOUTPUT="$(driftctl scan $qflag $INPUT_ARGS)"
+
+# Escape scan output to handle multilines
+SCANOUTPUT="${SCANOUTPUT//$'\n'/'%0A'}"
+
+# Set output to be used for other Github Actions jobs
+echo "::set-output name=driftctl::$SCANOUTPUT"
+
 # Finally we run the scan command
 driftctl scan $qflag $INPUT_ARGS
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,20 +61,19 @@ scan_output=$(scan_output)
 # Store exit code from scan command run in scan function
 scan_exit=$?
 
-# Check exit code, fail job if scan command exit code 2, then format scan output for GitHub comment
+# Check scan ﬁexit code, fail job if exit code is 1 or 2, then format scan output for GitHub comment
 scan_exit_code(){
-  if [ "$scan_exit" -eq 2 ]; then
+  if [[ "$scan_exit" -eq 1 || "$scan_exit" -eq 2 ]]; then
     echo -e "$scan_output"
     scan_output="${scan_output//$'\n'/'%0A'}"
+    echo "::set-output name=driftctl::$scan_output"
     exit 1
   else
     echo -e "$scan_output"
     scan_output="${scan_output//$'\n'/'%0A'}"
+    echo "::set-output name=driftctl::$scan_output"
   fi
 }
 
 # Run exit code function 
 scan_exit_code
-
-# Set output to be used for other Github Actions jobs
-echo "::set-output name=driftctl::$scan_output"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ scan_exit=$?
 
 # Check exit code, fail job if scan command exit code 2, then format scan output for GitHub comment
 scan_exit_code(){
-  if [ "$scan_exit" -eq 2 ]; then
+  if [[ "$scan_exit" -eq 1 || "$scan_exit" -eq 2 ]]; then
     echo -e "$scan_output"
     scan_output="${scan_output//$'\n'/'%0A'}"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,12 +49,15 @@ quiet_flag
 # Store scan output in variable 
 scan_output="$(driftctl scan $qflag $INPUT_ARGS)"
 
+# echo scan output to be consumed through Github Actions runner console
+echo -e "$scan_output"
+
 # Escape scan output to handle multilines
-scan_output="${SCAN_OUTPUT//$'\n'/'%0A'}"
+scan_output="${scan_output//$'\n'/'%0A'}"
 
 # Set output to be used for other Github Actions jobs
-echo "::set-output name=driftctl::$SCAN_OUTPUT"
+echo "::set-output name=driftctl::$scan_output"
 
-# Finally we run the scan command
-driftctl scan $qflag $INPUT_ARGS
+
+
 


### PR DESCRIPTION
# PR Checklist
|          Q         |       A               |
|--------------------|-----------------------|
| 🐛 Bug fix?        |           N            |
| 🚀 New feature?    |       Y          |
| ⚠ Deprecation?     |      N           |
| ❌ BC Break        |          N             |
| 🔗 Related issues  |       N                |
| ❓ Documentation   |       Y                |

## Description 
This PR adds [$GITHUB_OUTPUT](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) to the Docker entry point shell script to enable driftctl stdout to be consumed by other GitHub Actions jobs downstream.

## Testing
<img width="497" alt="Screen Shot 2022-05-11 at 10 17 30 pm" src="https://user-images.githubusercontent.com/36835356/167856590-779f7326-0aac-4d16-853a-a1d1f882363c.png">