### PR TITLE
Set umask 0022 before running scan

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,5 +55,8 @@ install_driftctl || log_error "Fail to install driftctl"
 qflag=""
 quiet_flag
 
+# Set umask so report created is readable to others
+umask 0022
+
 # Finally we run the scan command
 driftctl scan $qflag $INPUT_ARGS


### PR DESCRIPTION
when run as github action with `--output` param, like
```
--from tfstate+s3://${{ }} --output html://result.html
```

result file is 
```
-rw------- 1 root root 1040000 Dec 30 01:11 result.html
```

effectively blocking from being used as artifact later.

This changes umask so file should be readable to others.